### PR TITLE
Adding retry to rest client for gateway/internal errors

### DIFF
--- a/pyivia/core/system/configuration.py
+++ b/pyivia/core/system/configuration.py
@@ -73,13 +73,13 @@ class Configuration(object):
             If the request is successful the pending changes are returned as JSON and can be accessed from
             the response.json attribute
         """
-        response = self.client.get_json_wait(PENDING_CHANGES)
+        response = self.client.get_json(PENDING_CHANGES)
         response.success = response.status_code == 200
 
         return response
 
     def _deploy_pending_changes(self):
-        response = self.client.get_json_wait(PENDING_CHANGES_DEPLOY)
+        response = self.client.get_json(PENDING_CHANGES_DEPLOY)
         response.success = (response.status_code == 200
             and response.json.get("result", -1) == 0)
 

--- a/pyivia/core/system/configuration.py
+++ b/pyivia/core/system/configuration.py
@@ -73,13 +73,13 @@ class Configuration(object):
             If the request is successful the pending changes are returned as JSON and can be accessed from
             the response.json attribute
         """
-        response = self.client.get_json(PENDING_CHANGES)
+        response = self.client.get_json_wait(PENDING_CHANGES)
         response.success = response.status_code == 200
 
         return response
 
     def _deploy_pending_changes(self):
-        response = self.client.get_json(PENDING_CHANGES_DEPLOY)
+        response = self.client.get_json_wait(PENDING_CHANGES_DEPLOY)
         response.success = (response.status_code == 200
             and response.json.get("result", -1) == 0)
 

--- a/pyivia/util/restclient.py
+++ b/pyivia/util/restclient.py
@@ -30,6 +30,7 @@ class RESTClient(object):
         self._base_url = base_url
         self._username = username
         self._password = password
+        self._session = self._create_session()
 
     def delete(self, endpoint, accept_type="*/*"):
         url = self._base_url + endpoint
@@ -37,9 +38,7 @@ class RESTClient(object):
 
         self._log_request("DELETE", url, headers)
 
-        s = self._create_session()
-
-        r = s.delete(url=url, headers=headers, params=None, verify=self._verify)
+        r = self._session.delete(url=url, headers=headers, params=None, verify=self._verify)
 
         self._log_response(r.status_code, r.headers, r.content)
 
@@ -59,9 +58,7 @@ class RESTClient(object):
 
         self._log_request("GET", url, headers)
 
-        s = self._create_session()
-
-        r = s.get(
+        r = self._session.get(
             url=url, params=parameters, headers=headers, verify=self._verify)
 
         self._log_response(r.status_code, r.headers, r._content)
@@ -70,10 +67,6 @@ class RESTClient(object):
         r.close()
 
         return response
-    
-    def get_json_wait(self, endpoint, parameters=None):
-        return self.get_wait(
-            endpoint, accept_type="application/json", parameters=parameters)
 
     def get_json(self, endpoint, parameters=None):
         return self.get(
@@ -92,7 +85,7 @@ class RESTClient(object):
             try:
                 self._log_request("GET", url, None)
 
-                r = requests.get(url=url, verify=self._verify, timeout=1)
+                r = self._session.get(url=url, verify=self._verify, timeout=1)
 
                 self._log_response(r.status_code, r.headers, r.content)
 
@@ -114,7 +107,7 @@ class RESTClient(object):
 
         self._log_request("GET", url, headers)
 
-        with requests.get(url=url, headers=headers, verify=self._verify, stream=True) as r:
+        with self._session.get(url=url, headers=headers, verify=self._verify, stream=True) as r:
             self._log_response(r.status_code, r.headers, b"")
             with open(file_name, 'wb') as f:
                 for chunk in r.iter_content(chunk_size=8192):
@@ -134,9 +127,7 @@ class RESTClient(object):
 
         self._log_request("POST", url, headers)
 
-        s = self._create_session()
-
-        r = s.post(
+        r = self._session.post(
             url=url, headers=headers, params=parameters, data=data, verify=self._verify)
 
         self._log_response(r.status_code, r.headers, r.content)
@@ -153,9 +144,7 @@ class RESTClient(object):
 
         self._log_request("POST", url, headers)
 
-        s = self._create_session()
-
-        r = s.post(
+        r = self._session.post(
             url=url, headers=headers, data=data, files=files, params=parameters, verify=self._verify)
 
         self._log_response(r.status_code, r.headers, r.content)
@@ -177,9 +166,7 @@ class RESTClient(object):
 
         self._log_request("PUT", url, headers)
 
-        s = self._create_session()
-
-        r = s.put(
+        r = self._session.put(
             url=url, headers=headers, params=None, data=data, verify=self._verify)
 
         self._log_response(r.status_code, r.headers, r.content)
@@ -200,9 +187,7 @@ class RESTClient(object):
 
         self._log_request("PUT", url, headers)
 
-        s = self._create_session()
-
-        r = s.put(
+        r = self._session.put(
             url=url, headers=headers, data=data, files=files, params=parameters, verify=self._verify)
 
         self._log_response(r.status_code, r.headers, r.content)
@@ -264,7 +249,7 @@ class RESTClient(object):
             total=5,
             backoff_factor=0.1,
             status_forcelist=[500, 502, 503, 504],
-            allowed_methods={'DELETE','POST','PUT'},
+            allowed_methods={'GET','DELETE','POST','PUT'},
         )
         s.mount('https://', HTTPAdapter(max_retries=retries))
 

--- a/pyivia/util/restclient.py
+++ b/pyivia/util/restclient.py
@@ -10,12 +10,14 @@ import requests
 import time
 import os
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
+from requests.packages.urllib3.util import Retry
+from requests import Session
+from requests.adapters import HTTPAdapter
 
 from .model import Response
 
 
 logger = logging.getLogger(__name__)
-
 
 class RESTClient(object):
 
@@ -35,7 +37,9 @@ class RESTClient(object):
 
         self._log_request("DELETE", url, headers)
 
-        r = requests.delete(url=url, headers=headers, params=None, verify=self._verify)
+        s = self._create_session()
+
+        r = s.delete(url=url, headers=headers, params=None, verify=self._verify)
 
         self._log_response(r.status_code, r.headers, r.content)
 
@@ -55,7 +59,9 @@ class RESTClient(object):
 
         self._log_request("GET", url, headers)
 
-        r = requests.get(
+        s = self._create_session()
+
+        r = s.get(
             url=url, params=parameters, headers=headers, verify=self._verify)
 
         self._log_response(r.status_code, r.headers, r._content)
@@ -124,7 +130,9 @@ class RESTClient(object):
 
         self._log_request("POST", url, headers)
 
-        r = requests.post(
+        s = self._create_session()
+
+        r = s.post(
             url=url, headers=headers, params=parameters, data=data, verify=self._verify)
 
         self._log_response(r.status_code, r.headers, r.content)
@@ -141,7 +149,9 @@ class RESTClient(object):
 
         self._log_request("POST", url, headers)
 
-        r = requests.post(
+        s = self._create_session()
+
+        r = s.post(
             url=url, headers=headers, data=data, files=files, params=parameters, verify=self._verify)
 
         self._log_response(r.status_code, r.headers, r.content)
@@ -163,7 +173,9 @@ class RESTClient(object):
 
         self._log_request("PUT", url, headers)
 
-        r = requests.put(
+        s = self._create_session()
+
+        r = s.put(
             url=url, headers=headers, params=None, data=data, verify=self._verify)
 
         self._log_response(r.status_code, r.headers, r.content)
@@ -184,7 +196,9 @@ class RESTClient(object):
 
         self._log_request("PUT", url, headers)
 
-        r = requests.put(
+        s = self._create_session()
+
+        r = s.put(
             url=url, headers=headers, data=data, files=files, params=parameters, verify=self._verify)
 
         self._log_response(r.status_code, r.headers, r.content)
@@ -239,3 +253,15 @@ class RESTClient(object):
 
     def _log_response(self, status_code, headers, content):
         logger.debug("Response: %i headers=%s %s", status_code, headers, content)
+
+    def _create_session(self):
+        s = Session()
+        retries = Retry(
+            total=5,
+            backoff_factor=0.1,
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods={'DELETE','POST','PUT'},
+        )
+        s.mount('https://', HTTPAdapter(max_retries=retries))
+
+        return s

--- a/pyivia/util/restclient.py
+++ b/pyivia/util/restclient.py
@@ -70,6 +70,10 @@ class RESTClient(object):
         r.close()
 
         return response
+    
+    def get_json_wait(self, endpoint, parameters=None):
+        return self.get_wait(
+            endpoint, accept_type="application/json", parameters=parameters)
 
     def get_json(self, endpoint, parameters=None):
         return self.get(


### PR DESCRIPTION
We are seeing 500 errors temporarily on several endpoints when running automation, typically when deploying and publishing. This change will add a few retries on 500, 502, 503 and 504 status codes increasing the possibility that deployment/publish would succeed. 